### PR TITLE
LSN introspection

### DIFF
--- a/lib/replisome/receivers/base.py
+++ b/lib/replisome/receivers/base.py
@@ -44,6 +44,8 @@ class BaseReceiver(object):
 
         if slot_create:
             self.create_slot()
+        if lsn is None:
+            lsn = self.get_restart_lsn()
 
         connection = self.create_connection()
         if not connection.async_:
@@ -89,7 +91,7 @@ class BaseReceiver(object):
             sql.SQL('START_REPLICATION SLOT '),
             sql.Identifier(self.slot),
             sql.SQL(' LOGICAL '),
-            sql.SQL(lsn or '0/0')]
+            sql.SQL(lsn)]
 
         if self.options:
             bits.append(sql.SQL(' ('))
@@ -137,6 +139,26 @@ class BaseReceiver(object):
         wait_select(cnn)
         return cnn
 
+    def get_restart_lsn(self):
+        """
+        Returns the restart LSN for the replication slot as stored in the
+        pg_replication_slots DB table. Returns default start position if
+        slot doesn't exist.
+
+        :return: string containing restart LSN for current slot
+        """
+        command = '''
+        SELECT restart_lsn FROM pg_replication_slots WHERE slot_name = %s
+        '''
+        lsn = '0/0'
+        try:
+            with psycopg2.connect(self.dsn) as conn, conn.cursor() as cursor:
+                cursor.execute(command, [self.slot])
+                lsn = cursor.fetchone()[0]
+        except psycopg2.Error as e:
+            self.logger.error('error retrieving LSN: %s', e)
+        return lsn
+
     def create_slot(self):
         """
         Creates the replication slot, if it hasn't been created already.
@@ -163,8 +185,7 @@ FROM new_slots
             with psycopg2.connect(self.dsn) as conn, conn.cursor() as cursor:
                 cursor.execute(command, (self.slot, self.plugin, self.slot))
         except psycopg2.Error as e:
-            self.logger.error(
-                'error dropping replication slot: %s', e)
+            self.logger.error('error creating replication slot: %s', e)
 
     def drop_slot(self):
         try:
@@ -173,8 +194,7 @@ FROM new_slots
                 self.logger.info('dropping replication slot "%s"', self.slot)
                 cur.drop_replication_slot(self.slot)
         except Exception as e:
-            self.logger.error(
-                'error dropping replication slot: %s', e)
+            self.logger.error('error dropping replication slot: %s', e)
 
     def close(self, connection):
         try:

--- a/lib/replisome/receivers/base.py
+++ b/lib/replisome/receivers/base.py
@@ -60,9 +60,11 @@ class BaseReceiver(object):
         if block:
             while self.on_loop(connection, cur):
                 pass
-
-        cur.close()
-        return connection
+            cur.close()
+            connection.close()
+        else:
+            cur.close()
+            return connection
 
     def on_loop(self, connection, cursor):
         is_running = True

--- a/lib/replisome/receivers/json.py
+++ b/lib/replisome/receivers/json.py
@@ -78,7 +78,10 @@ class JsonReceiver(BaseReceiver):
             chunk[:70], len(chunk) > 70 and '...' or '')
         self._chunks.append(chunk)
 
-        if chunk == u']}' or chunk == u'\t]\n}':
+        # attempt parsing each chunk as part of the whole
+        try:
             obj = json.loads(''.join(self._chunks))
             del self._chunks[:]
             self.message_cb(obj)
+        except json.JSONDecodeError:
+            pass

--- a/lib/replisome/receivers/test_decoding.py
+++ b/lib/replisome/receivers/test_decoding.py
@@ -5,6 +5,17 @@ __all__ = ['TestDecodingReceiver']
 
 class TestDecodingReceiver(BaseReceiver):
 
+    @classmethod
+    def from_config(cls, config):
+        opts = []
+        for k in ('include-xids', 'include-timestamp', 'skip-empty-xacts',
+                  'only-local', 'include-rewrites', 'force-binary'):
+            if k in config:
+                v = config.pop(k)
+                opts.append((k, (v and 't' or 'f')))
+
+        return cls(options=opts)
+
     def process_payload(self, raw_payload):
         payload = raw_payload.decode('utf-8')
         self.logger.debug(

--- a/lib/replisome/version.py
+++ b/lib/replisome/version.py
@@ -6,7 +6,7 @@ VERSION = '0.2.0'
 
 # Complain if the server doesn't speak a version between these two
 SERVER_MIN_VER = StrictVersion('0.1')
-SERVER_MAX_VER = StrictVersion('0.2')
+SERVER_MAX_VER = StrictVersion('0.3')
 
 
 def check_version(ver):

--- a/lib/replisome/version.py
+++ b/lib/replisome/version.py
@@ -2,7 +2,7 @@ from distutils.version import StrictVersion
 
 from .errors import ReplisomeError
 
-VERSION = '0.2.0'
+VERSION = '0.2.1'
 
 # Complain if the server doesn't speak a version between these two
 SERVER_MIN_VER = StrictVersion('0.1')

--- a/tests/pytests/test_data_updater.py
+++ b/tests/pytests/test_data_updater.py
@@ -12,7 +12,7 @@ def test_insert(src_db, tgt_db, called):
     c = called(du, 'process_message')
 
     jr = JsonReceiver(slot=src_db.slot, message_cb=du.process_message)
-    src_db.thread_receive(jr, src_db.make_repl_conn())
+    src_db.thread_receive(jr, src_db.dsn)
 
     scur = src_db.conn.cursor()
     tcur = tgt_db.conn.cursor()
@@ -74,9 +74,8 @@ def test_insert_missing_table(src_db, tgt_db, called):
     du = DataUpdater(tgt_db.conn.dsn, skip_missing_columns=True)
     c = called(du, 'process_message')
 
-    rconn = src_db.make_repl_conn()
     jr = JsonReceiver(slot=src_db.slot, message_cb=du.process_message)
-    src_db.thread_receive(jr, rconn)
+    src_db.thread_receive(jr, src_db.dsn)
 
     scur = src_db.conn.cursor()
     tcur = tgt_db.conn.cursor()
@@ -92,12 +91,11 @@ def test_insert_missing_table(src_db, tgt_db, called):
         c.get()
 
     jr.stop()
-    rconn.close()
 
     tcur.execute("create table testins (id serial primary key, data text)")
 
     jr = JsonReceiver(slot=src_db.slot, message_cb=du.process_message)
-    src_db.thread_receive(jr, src_db.make_repl_conn())
+    src_db.thread_receive(jr, src_db.dsn)
     c.get()
 
     tcur.execute("select * from testins")
@@ -108,9 +106,8 @@ def test_insert_missing_col(src_db, tgt_db, called):
     du = DataUpdater(tgt_db.conn.dsn)
     c = called(du, 'process_message')
 
-    rconn = src_db.make_repl_conn()
     jr = JsonReceiver(slot=src_db.slot, message_cb=du.process_message)
-    src_db.thread_receive(jr, rconn)
+    src_db.thread_receive(jr, src_db.dsn)
 
     scur = src_db.conn.cursor()
     tcur = tgt_db.conn.cursor()
@@ -134,14 +131,13 @@ def test_insert_missing_col(src_db, tgt_db, called):
     assert tcur.fetchall() == []
 
     jr.stop()
-    rconn.close()
     tcur.execute("alter table testins add more text")
 
     du = DataUpdater(tgt_db.conn.dsn)
     c = called(du, 'process_message')
 
     jr = JsonReceiver(slot=src_db.slot, message_cb=du.process_message)
-    src_db.thread_receive(jr, src_db.make_repl_conn())
+    src_db.thread_receive(jr, src_db.dsn)
 
     c.get()
     tcur.execute("select * from testins")
@@ -153,7 +149,7 @@ def test_insert_conflict(src_db, tgt_db, called):
     c = called(du, 'process_message')
 
     jr = JsonReceiver(slot=src_db.slot, message_cb=du.process_message)
-    src_db.thread_receive(jr, src_db.make_repl_conn())
+    src_db.thread_receive(jr, src_db.dsn)
 
     scur = src_db.conn.cursor()
     tcur = tgt_db.conn.cursor()
@@ -193,7 +189,7 @@ def test_insert_conflict_do_nothing(src_db, tgt_db, called):
     c = called(du, 'process_message')
 
     jr = JsonReceiver(slot=src_db.slot, message_cb=du.process_message)
-    src_db.thread_receive(jr, src_db.make_repl_conn())
+    src_db.thread_receive(jr, src_db.dsn)
 
     scur = src_db.conn.cursor()
     tcur = tgt_db.conn.cursor()
@@ -228,7 +224,7 @@ def test_update(src_db, tgt_db, called):
     c = called(du, 'process_message')
 
     jr = JsonReceiver(slot=src_db.slot, message_cb=du.process_message)
-    src_db.thread_receive(jr, src_db.make_repl_conn())
+    src_db.thread_receive(jr, src_db.dsn)
 
     scur = src_db.conn.cursor()
     tcur = tgt_db.conn.cursor()
@@ -285,9 +281,8 @@ def test_update_missing_table(src_db, tgt_db, called):
     du = DataUpdater(tgt_db.conn.dsn, skip_missing_columns=True)
     c = called(du, 'process_message')
 
-    rconn = src_db.make_repl_conn()
     jr = JsonReceiver(slot=src_db.slot, message_cb=du.process_message)
-    src_db.thread_receive(jr, rconn)
+    src_db.thread_receive(jr, src_db.dsn)
 
     scur = src_db.conn.cursor()
     tcur = tgt_db.conn.cursor()
@@ -310,12 +305,11 @@ def test_update_missing_table(src_db, tgt_db, called):
         c.get()
 
     jr.stop()
-    rconn.close()
 
     tcur.execute("alter table testins rename to testins2")
 
     jr = JsonReceiver(slot=src_db.slot, message_cb=du.process_message)
-    src_db.thread_receive(jr, src_db.make_repl_conn())
+    src_db.thread_receive(jr, src_db.dsn)
     c.get()
 
     tcur.execute("select * from testins2")
@@ -326,9 +320,8 @@ def test_update_missing_col(src_db, tgt_db, called):
     du = DataUpdater(tgt_db.conn.dsn)
     c = called(du, 'process_message')
 
-    rconn = src_db.make_repl_conn()
     jr = JsonReceiver(slot=src_db.slot, message_cb=du.process_message)
-    src_db.thread_receive(jr, rconn)
+    src_db.thread_receive(jr, src_db.dsn)
 
     scur = src_db.conn.cursor()
     tcur = tgt_db.conn.cursor()
@@ -361,12 +354,11 @@ def test_update_missing_col(src_db, tgt_db, called):
     assert rs == [(1, 'hello'), (2, 'world')]
 
     jr.stop()
-    rconn.close()
 
     tcur.execute("alter table testup add more text")
 
     jr = JsonReceiver(slot=src_db.slot, message_cb=du.process_message)
-    src_db.thread_receive(jr, src_db.make_repl_conn())
+    src_db.thread_receive(jr, src_db.dsn)
     c.get()
 
     tcur.execute("select id, data, more from testup order by id")
@@ -380,7 +372,7 @@ def test_delete(src_db, tgt_db, called):
     c = called(du, 'process_message')
 
     jr = JsonReceiver(slot=src_db.slot, message_cb=du.process_message)
-    src_db.thread_receive(jr, src_db.make_repl_conn())
+    src_db.thread_receive(jr, src_db.dsn)
 
     scur = src_db.conn.cursor()
     tcur = tgt_db.conn.cursor()
@@ -425,9 +417,8 @@ def test_delete_missing_table(src_db, tgt_db, called):
     du = DataUpdater(tgt_db.conn.dsn, skip_missing_columns=True)
     c = called(du, 'process_message')
 
-    rconn = src_db.make_repl_conn()
     jr = JsonReceiver(slot=src_db.slot, message_cb=du.process_message)
-    src_db.thread_receive(jr, rconn)
+    src_db.thread_receive(jr, src_db.dsn)
 
     scur = src_db.conn.cursor()
     tcur = tgt_db.conn.cursor()
@@ -451,12 +442,11 @@ def test_delete_missing_table(src_db, tgt_db, called):
         c.get()
 
     jr.stop()
-    rconn.close()
 
     tcur.execute("alter table testins rename to testins2")
 
     jr = JsonReceiver(slot=src_db.slot, message_cb=du.process_message)
-    src_db.thread_receive(jr, src_db.make_repl_conn())
+    src_db.thread_receive(jr, src_db.dsn)
     c.get()
 
     tcur.execute("select * from testins2")
@@ -467,9 +457,8 @@ def test_toast(src_db, tgt_db, called):
     du = DataUpdater(tgt_db.conn.dsn, skip_missing_columns=True)
     c = called(du, 'process_message')
 
-    rconn = src_db.make_repl_conn()
     jr = JsonReceiver(slot=src_db.slot, message_cb=du.process_message)
-    src_db.thread_receive(jr, rconn)
+    src_db.thread_receive(jr, src_db.dsn)
 
     scur = src_db.conn.cursor()
     tcur = tgt_db.conn.cursor()
@@ -549,9 +538,8 @@ def test_numeric(src_db, tgt_db, called):
     du = DataUpdater(tgt_db.conn.dsn)
     c = called(du, 'process_message')
 
-    rconn = src_db.make_repl_conn()
     jr = JsonReceiver(slot=src_db.slot, message_cb=du.process_message)
-    src_db.thread_receive(jr, rconn)
+    src_db.thread_receive(jr, src_db.dsn)
 
     scur = src_db.conn.cursor()
     tcur = tgt_db.conn.cursor()


### PR DESCRIPTION
Changed default to pull latest LSN from DB table instead of defaulting to 0/0, which led to the WAL cache backing up.
Some attempts at fixing tests (more work to do here)