### PR TITLE
Configurability Updates

### DIFF
--- a/lib/replisome/consumers/data.py
+++ b/lib/replisome/consumers/data.py
@@ -79,7 +79,7 @@ class DataUpdater(object):
             return
 
         elif status != ext.TRANSACTION_STATUS_IDLE:
-            logger.warn("rolling back transaction in status %s", status)
+            logger.warning("rolling back transaction in status %s", status)
             cnn.rollback()
 
         self._connection = cnn

--- a/lib/replisome/receivers/base.py
+++ b/lib/replisome/receivers/base.py
@@ -116,7 +116,7 @@ class BaseReceiver(object):
         # shutdown requested, clean up
         if self._shutdown_pipe[0] in result[0]:
             # do final flush on clean shutdown
-            self.cursor.send_feedback()
+            self.cursor.send_feedback(flush_lsn=self.flush_lsn)
             self.is_running = False
             self.close()
 

--- a/lib/replisome/receivers/json.py
+++ b/lib/replisome/receivers/json.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import
+
 import json
 
 import psycopg2
@@ -83,5 +85,5 @@ class JsonReceiver(BaseReceiver):
             obj = json.loads(''.join(self._chunks))
             del self._chunks[:]
             self.message_cb(obj)
-        except json.JSONDecodeError:
+        except ValueError:
             pass

--- a/lib/replisome/version.py
+++ b/lib/replisome/version.py
@@ -2,11 +2,11 @@ from distutils.version import StrictVersion
 
 from .errors import ReplisomeError
 
-VERSION = '0.3.0'
+VERSION = '0.4.0'
 
 # Complain if the server doesn't speak a version between these two
 SERVER_MIN_VER = StrictVersion('0.1')
-SERVER_MAX_VER = StrictVersion('0.4')
+SERVER_MAX_VER = StrictVersion('0.5')
 
 
 def check_version(ver):

--- a/src/executor.c
+++ b/src/executor.c
@@ -45,7 +45,11 @@ create_estate_for_relation(Relation rel, bool hasTriggers)
 	rte->relkind = rel->rd_rel->relkind;
 
 	resultRelInfo = makeNode(ResultRelInfo);
+#if PG_VERSION_NUM >= 100000
+	InitResultRelInfo(resultRelInfo, rel, 1, NULL, 0);
+#else
 	InitResultRelInfo(resultRelInfo, rel, 1, 0);
+#endif
 
 	/* Initialize executor state. */
 	estate = CreateExecutorState();

--- a/src/replisome.c
+++ b/src/replisome.c
@@ -769,7 +769,11 @@ rs_decode_change(LogicalDecodingContext *ctx, ReorderBufferTXN *txn,
 		econtext = prepare_per_tuple_econtext(entry->estate, tupdesc);
 		ExecStoreTuple(newtup ? newtup : oldtup, econtext->ecxt_scantuple,
 			InvalidBuffer, false);
+#if PG_VERSION_NUM >= 100000
+		res = ExecEvalExpr(entry->exprstate, econtext, &isnull);
+#else
 		res = ExecEvalExpr(entry->exprstate, econtext, &isnull, NULL);
+#endif
 		ExecDropSingleTupleTableSlot(econtext->ecxt_scantuple);
 
 		/* NULL is same as false for our use. */

--- a/tests/pytests/fix_db.py
+++ b/tests/pytests/fix_db.py
@@ -1,10 +1,15 @@
+import time
 import os
+import logging
+from datetime import datetime, timedelta
 from threading import Thread
 
 import pytest
 import psycopg2
 
 from replisome.errors import ReplisomeError
+
+logger = logging.getLogger(__name__)
 
 
 @pytest.fixture
@@ -13,15 +18,13 @@ def src_db():
     dsn = os.environ.get(
         "RS_TEST_SRC_DSN",
         'host=localhost dbname=rs_src_test')
-    db = TestDatabase(dsn)
-    db.drop_slot()
-    db.create_slot(if_not_exists=True)
+    db = TestDatabase(dsn, slot='rs_test_slot')
 
     # Create the extension to make the version number available
-    cnn = db.make_conn()
-    cur = cnn.cursor()
-    cur.execute('drop extension if exists replisome')
-    cur.execute('create extension replisome')
+    with db.make_conn() as cnn:
+        cur = cnn.cursor()
+        cur.execute('drop extension if exists replisome')
+        cur.execute('create extension replisome')
     cnn.close()
 
     yield db
@@ -46,17 +49,16 @@ class TestDatabase(object):
     The database can be the sender of the receiver: a few methods may make
     sense only in one case.
 
-    The object manages one replication slot.
+    The object optionally manages teardown for one replication slot.
     """
-    def __init__(self, dsn):
+    def __init__(self, dsn, slot=None):
         self.dsn = dsn
-        self.slot = 'rs_test_slot'
+        self.slot = slot
         self.plugin = 'replisome'
 
         self._conn = None
         self._conns = []
         self._threads = []
-        self._slot_created = False
 
     @property
     def conn(self):
@@ -76,13 +78,15 @@ class TestDatabase(object):
         Invoked at the end of the tests.
         """
         for thread in self._threads:
-            thread.stop()
-            thread.join()
+            if thread is not None:
+                thread.stop()
+                thread.join()
 
         for cnn in self._conns:
             cnn.close()
 
-        if self._slot_created:
+        if self.slot:
+            logger.debug('Dropping replication slot')
             self.drop_slot()
 
     def make_conn(self, autocommit=True, **kwargs):
@@ -109,48 +113,38 @@ class TestDatabase(object):
         # other connections (maybe using the slot) have been closed.
         cnn.close()
 
-    def create_slot(self, if_not_exists=False):
-        """Create the replication slot.
-
-        :param if_not_exists:
-            If True and the slot exists don't do anything.
-            If False create the slot (if it exists, die of error)
+    def run_receiver(self, receiver, dsn):
         """
-        with self.make_conn() as cnn:
-            cur = cnn.cursor()
-            if if_not_exists:
-                cur.execute("""
-                    select 1 from pg_replication_slots where slot_name = %s
-                    """, (self.slot,))
-                if cur.fetchone():
-                    return
-
-            cur.execute(
-                "select pg_create_logical_replication_slot(%s, %s)",
-                [self.slot, self.plugin])
-
-            self._slot_created = True
-
-    def thread_receive(self, receiver, dsn, target=None):
-        """
-        Run the receiver loop of a receiver in a thread.
+        Run a receiver loop in a thread.
 
         Stop the receiver at the end of the test.
         """
-        def thread_receive_(cur_dsn):
-            try:
-                receiver.dsn = cur_dsn
-                receiver.start()
-            except ReplisomeError:
-                pass
-        if target is None:
-            target = thread_receive_
+        receiver.dsn = dsn
+        return self.add_thread(receiver)
 
-        self.thread_run(target, receiver.stop_blocking, args=(dsn,))
+    def run_pipeline(self, pipeline):
+        """
+        Runs the given pipeline in a thread. Stops pipeline at end of the test.
 
-    def thread_run(self, target, at_exit, args=()):
-        """Call a function in a thread. Call another function on stop."""
-        t = Thread(target=target, args=args)
-        t.stop = at_exit
-        t.start()
-        self._threads.append(t)
+        :param: pipeline
+        """
+        return self.add_thread(pipeline)
+
+    def add_thread(self, obj, timeout=timedelta(seconds=1)):
+        thread = Thread(target=obj.start)
+        thread.stop = obj.stop
+        thread.start()
+        start_time = datetime.utcnow()
+        while not obj.is_running:
+            if (start_time + timeout) < datetime.utcnow():
+                raise TimeoutError()
+            time.sleep(0.01)
+        self._threads.append(thread)
+        return len(self._threads) - 1
+
+    def remove_thread(self, thread_index):
+        thread = self._threads[thread_index]
+        thread.stop()
+        thread.join()
+        self._threads[thread_index] = None
+

--- a/tests/pytests/fix_db.py
+++ b/tests/pytests/fix_db.py
@@ -7,8 +7,6 @@ from threading import Thread
 import pytest
 import psycopg2
 
-from replisome.errors import ReplisomeError
-
 logger = logging.getLogger(__name__)
 
 

--- a/tests/pytests/test_config.py
+++ b/tests/pytests/test_config.py
@@ -1,3 +1,4 @@
+import time
 import yaml
 import pytest
 
@@ -88,7 +89,7 @@ def test_pipeline(configfile, src_db, tgt_db, called):
     pl = config.make_pipeline(conf)
     c = called(pl.consumer, 'process_message')
 
-    src_db.thread_run(pl.start, pl.stop)
+    src_db.run_pipeline(pl)
 
     scur.execute("""
         insert into myapp.account (username, password) values

--- a/tests/pytests/test_config.py
+++ b/tests/pytests/test_config.py
@@ -1,4 +1,3 @@
-import time
 import yaml
 import pytest
 
@@ -87,6 +86,7 @@ def test_pipeline(configfile, src_db, tgt_db, called):
 
     conf = config.parse_yaml(configfile)
     pl = config.make_pipeline(conf)
+    pl.receiver.blocking_wait = 0.1
     c = called(pl.consumer, 'process_message')
 
     src_db.run_pipeline(pl)

--- a/tests/pytests/test_data_updater.py
+++ b/tests/pytests/test_data_updater.py
@@ -1,5 +1,6 @@
 import pytest
 from decimal import Decimal
+import time
 
 from replisome.errors import ReplisomeError
 from replisome.consumers import DataUpdater
@@ -90,7 +91,7 @@ def test_insert_missing_table(src_db, tgt_db, called):
     with pytest.raises(ReplisomeError):
         c.get()
 
-    jr.stop()
+    jr.stop_blocking()
 
     tcur.execute("create table testins (id serial primary key, data text)")
 
@@ -130,7 +131,7 @@ def test_insert_missing_col(src_db, tgt_db, called):
     tcur.execute("select * from testins")
     assert tcur.fetchall() == []
 
-    jr.stop()
+    jr.stop_blocking()
     tcur.execute("alter table testins add more text")
 
     du = DataUpdater(tgt_db.conn.dsn)
@@ -304,7 +305,7 @@ def test_update_missing_table(src_db, tgt_db, called):
     with pytest.raises(ReplisomeError):
         c.get()
 
-    jr.stop()
+    jr.stop_blocking()
 
     tcur.execute("alter table testins rename to testins2")
 
@@ -353,7 +354,7 @@ def test_update_missing_col(src_db, tgt_db, called):
     rs = tcur.fetchall()
     assert rs == [(1, 'hello'), (2, 'world')]
 
-    jr.stop()
+    jr.stop_blocking()
 
     tcur.execute("alter table testup add more text")
 
@@ -441,7 +442,7 @@ def test_delete_missing_table(src_db, tgt_db, called):
     with pytest.raises(ReplisomeError):
         c.get()
 
-    jr.stop()
+    jr.stop_blocking()
 
     tcur.execute("alter table testins rename to testins2")
 

--- a/tests/pytests/test_data_updater.py
+++ b/tests/pytests/test_data_updater.py
@@ -277,7 +277,6 @@ def test_update(src_db, tgt_db, called):
     assert tcur.fetchone()[0] == 3
 
 
-@pytest.mark.xfail
 def test_update_missing_table(src_db, tgt_db, called):
     du = DataUpdater(tgt_db.conn.dsn, skip_missing_columns=True)
     c = called(du, 'process_message')
@@ -320,7 +319,6 @@ def test_update_missing_table(src_db, tgt_db, called):
     assert tcur.fetchall() == [(1, 'world')]
 
 
-@pytest.mark.xfail
 def test_update_missing_col(src_db, tgt_db, called):
     du = DataUpdater(tgt_db.conn.dsn)
     c = called(du, 'process_message')
@@ -421,14 +419,14 @@ def test_delete(src_db, tgt_db, called):
     assert tcur.fetchone()[0] == 4
 
 
-@pytest.mark.xfail
 def test_delete_missing_table(src_db, tgt_db, called):
     du = DataUpdater(tgt_db.conn.dsn, skip_missing_columns=True)
     c = called(du, 'process_message')
 
     jr = JsonReceiver(slot=src_db.slot,
                       message_cb=du.process_message,
-                      flush_interval=0)
+                      flush_interval=0,
+                      block_wait=0.1)
     jr_thread = src_db.run_receiver(jr, src_db.dsn)
 
     scur = src_db.conn.cursor()

--- a/tests/pytests/test_data_updater.py
+++ b/tests/pytests/test_data_updater.py
@@ -425,8 +425,7 @@ def test_delete_missing_table(src_db, tgt_db, called):
 
     jr = JsonReceiver(slot=src_db.slot,
                       message_cb=du.process_message,
-                      flush_interval=0,
-                      block_wait=0.1)
+                      flush_interval=0)
     jr_thread = src_db.run_receiver(jr, src_db.dsn)
 
     scur = src_db.conn.cursor()

--- a/tests/pytests/test_json_receiver.py
+++ b/tests/pytests/test_json_receiver.py
@@ -80,7 +80,7 @@ def test_insert(src_db):
     assert 'keytypes' not in c
     assert 'oldkey' not in c
 
-    jr.stop()
+    jr.stop_blocking()
 
 
 def test_break_half_message(src_db):
@@ -117,7 +117,7 @@ def test_break_half_message(src_db):
     else:
         pytest.fail("not broken enough, got message %s" % d)
 
-    jr.stop()
+    jr.stop_blocking()
 
     # Replace the receiver with something working
     jr = JsonReceiver(slot=src_db.slot, message_cb=r.receive)


### PR DESCRIPTION
Moved farther from original Replisome behaviour:
* slot creation always attempted now in start
* async connection only
* new `is_running` property on pipeline
* WAL flush is done every 10 seconds instead of after every successful message process.

Loop control uses the same shutdown behaviour now, with improved CPU usage when done manually.
Made a number of variables configurable in receiver - timeout during socket select, interval between WAL flushes.
Updated tests to work with new behaviour. 3 tests do not fully work yet :(
Minor modifications to replisome plugin for compiling and running in Postgresql 10+.